### PR TITLE
Improve packaging support for  staticWhich usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/src/System/Which.hs
+++ b/src/System/Which.hs
@@ -23,11 +23,7 @@ staticWhich f = do
   mf' <- runIO $ which f
   case mf' of
     Nothing -> compileError $ "Could not find executable for " <> show f
-    Just f'
-      | "/nix/store/" `isPrefixOf` f' -> [| f' |]
-      | otherwise -> compileError $
-        "Path to executable " <> show f <> " was found in " <> show f'
-        <> " which is not in /nix/store. Be sure to add the relevant package to default.nix."
+    Just f' -> [| f' |]
 
   where
     compileError msg' = do

--- a/src/System/Which.hs
+++ b/src/System/Which.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings, TemplateHaskell #-}
-module System.Which where
+module System.Which (which, staticWhich) where
 
 import qualified Shelly as Sh
 import qualified Data.Text as T

--- a/src/System/Which.hs
+++ b/src/System/Which.hs
@@ -7,13 +7,17 @@ import Language.Haskell.TH (Exp, Q, reportError, runIO)
 import Data.Monoid ((<>))
 import Data.List (isPrefixOf)
 
--- | Determine which executable would run if the given path were executed, or return Nothing if a suitable executable cannot be found
+-- | Determine which executable would run if the given path were
+--   executed, or return Nothing if a suitable executable cannot be
+--   found
 which :: FilePath -> IO (Maybe FilePath)
 which f = fmap (fmap (T.unpack . Sh.toTextIgnore)) $ Sh.shelly $ Sh.which $ Sh.fromText $ T.pack f
 
 -- | Run `which` at compile time, and substitute the full path to the executable.
 --
--- This is useful in NixOS to ensure that the resulting executable contains the dependency in its closure and that it refers to the same version at run time as at compile time
+-- This is useful in NixOS to ensure that the resulting executable
+-- contains the dependency in its closure and that it refers to the
+-- same version at run time as at compile time
 staticWhich :: FilePath -> Q Exp
 staticWhich f = do
   mf' <- runIO $ which f
@@ -21,7 +25,9 @@ staticWhich f = do
     Nothing -> compileError $ "Could not find executable for " <> show f
     Just f'
       | "/nix/store/" `isPrefixOf` f' -> [| f' |]
-      | otherwise -> compileError $ "Path to executable " <> show f <> " was found in " <> show f' <> " which is not in /nix/store. Be sure to add the relevant package to 'backendTools' in default.nix."
+      | otherwise -> compileError $
+        "Path to executable " <> show f <> " was found in " <> show f'
+        <> " which is not in /nix/store. Be sure to add the relevant package to 'backendTools' in default.nix."
 
   where
     compileError msg' = do

--- a/src/System/Which.hs
+++ b/src/System/Which.hs
@@ -38,7 +38,7 @@ staticWhich f = do
       | "/nix/store/" `isPrefixOf` f' -> [| f' |]
       | otherwise -> compileError $
         "Path to executable " <> show f <> " was found in " <> show f'
-        <> " which is not in /nix/store. Be sure to add the relevant package to 'backendTools' in default.nix."
+        <> " which is not in /nix/store. Be sure to add the relevant package to default.nix."
 
   where
     compileError msg' = do

--- a/src/System/Which.hs
+++ b/src/System/Which.hs
@@ -27,7 +27,7 @@ staticWhich f = do
       | "/nix/store/" `isPrefixOf` f' -> [| f' |]
       | otherwise -> compileError $
         "Path to executable " <> show f <> " was found in " <> show f'
-        <> " which is not in /nix/store. Be sure to add the relevant package to 'backendTools' in default.nix."
+        <> " which is not in /nix/store. Be sure to add the relevant package to default.nix."
 
   where
     compileError msg' = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -32,7 +32,11 @@ setup = do
   appendFile (bin3 </> "hello") "hello"
   makeExecutable $ bin3 </> "hello"
   appendFile (bin3 </> "hello2") "hello2"
+
+  -- Don’t make this one executable to make sure we don’t resolve
+  -- non-executable exes below.
   -- makeExecutable $ bin3 </> "hello2"
+
   appendFile (bin3 </> "hello3") "hello3"
   makeExecutable $ bin3 </> "hello3"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,87 @@
+import Control.Exception
+import Control.Monad
+import Data.List
+import System.Directory
+import System.Environment
+import System.Exit
+import System.FilePath
+import System.Posix.Temp
+import System.Which
+
+shouldEqual :: Eq a => Show a => a -> a -> IO ()
+shouldEqual a b = when (a /= b) $ do
+  putStrLn $ show a <> " does not equal " <> show b
+  exitFailure
+
+setup :: IO (FilePath, FilePath, FilePath)
+setup = do
+  bin <- mkdtemp "bin"
+  bin2 <- mkdtemp "bin2"
+  bin3 <- mkdtemp "bin3"
+
+  let makeExecutable f = setPermissions f . setOwnerExecutable True =<< getPermissions f
+
+  appendFile (bin </> "hello") "hello"
+  makeExecutable $ bin </> "hello"
+  appendFile (bin2 </> "hello") "hello2"
+  makeExecutable $ bin2 </> "hello"
+  appendFile (bin2 </> "hello2") "hello2"
+  makeExecutable $ bin2 </> "hello2"
+  appendFile (bin3 </> "hello") "hello"
+  makeExecutable $ bin3 </> "hello"
+  appendFile (bin3 </> "hello2") "hello2"
+  -- makeExecutable $ bin3 </> "hello2"
+  appendFile (bin3 </> "hello3") "hello3"
+  makeExecutable $ bin3 </> "hello3"
+
+  pure (bin, bin2, bin3)
+
+cleanup :: (FilePath, FilePath, FilePath) -> IO ()
+cleanup (bin, bin2, bin3) = do
+  removeDirectoryRecursive bin
+  removeDirectoryRecursive bin2
+  removeDirectoryRecursive bin3
+
+main :: IO ()
+main = do
+  bracket setup cleanup $ \(bin, bin2, bin3) -> do
+    unsetEnv "PATH"
+    unsetEnv "HOST_PATH"
+
+    fp <- which "hello"
+
+    shouldEqual fp Nothing
+
+    setEnv "PATH" $ concat $ intersperse ":" [bin, bin2, bin3]
+    setEnv "HOST_PATH" $ concat $ intersperse ":" [bin, bin2]
+
+    fp1 <- which "hello"
+    fp2 <- which "hello2"
+    fp3 <- which "hello3"
+
+    shouldEqual fp1 (Just $ bin </> "hello")
+    shouldEqual fp2 (Just $ bin2 </> "hello2")
+    shouldEqual fp3 Nothing
+
+    unsetEnv "PATH"
+
+    fp4 <- which "hello"
+    fp5 <- which "hello2"
+    fp6 <- which "hello3"
+
+    shouldEqual fp4 (Just $ bin </> "hello")
+    shouldEqual fp5 (Just $ bin2 </> "hello2")
+    shouldEqual fp6 Nothing
+
+    unsetEnv "HOST_PATH"
+    setEnv "PATH" $ concat $ intersperse ":" [bin3, bin2, bin]
+
+    fp7 <- which "hello"
+    fp8 <- which "hello2"
+    fp9 <- which "hello3"
+
+    shouldEqual fp7 (Just $ bin3 </> "hello")
+    shouldEqual fp8 (Just $ bin2 </> "hello2")
+    shouldEqual fp9 (Just $ bin3 </> "hello3")
+
+    pure ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,6 @@
 import Control.Exception
 import Data.List
+import Data.Monoid ((<>))
 import System.Directory
 import System.Environment
 import System.Exit

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,4 @@
 import Control.Exception
-import Control.Monad
 import Data.List
 import System.Directory
 import System.Environment
@@ -9,17 +8,19 @@ import System.Posix.Temp
 import System.Which
 
 shouldEqual :: Eq a => Show a => a -> a -> IO ()
-shouldEqual a b = when (a /= b) $ do
+shouldEqual a b | a /= b = do
   putStrLn $ show a <> " does not equal " <> show b
   exitFailure
+shouldEqual a b = putStrLn $ show a <> " == " <> show b
+
+makeExecutable :: FilePath -> IO ()
+makeExecutable f = setPermissions f . setOwnerExecutable True =<< getPermissions f
 
 setup :: IO (FilePath, FilePath, FilePath)
 setup = do
   bin <- mkdtemp "bin"
   bin2 <- mkdtemp "bin2"
   bin3 <- mkdtemp "bin3"
-
-  let makeExecutable f = setPermissions f . setOwnerExecutable True =<< getPermissions f
 
   appendFile (bin </> "hello") "hello"
   makeExecutable $ bin </> "hello"
@@ -43,45 +44,44 @@ cleanup (bin, bin2, bin3) = do
   removeDirectoryRecursive bin3
 
 main :: IO ()
-main = do
-  bracket setup cleanup $ \(bin, bin2, bin3) -> do
-    unsetEnv "PATH"
-    unsetEnv "HOST_PATH"
+main = bracket setup cleanup $ \(bin, bin2, bin3) -> do
+  unsetEnv "PATH"
+  unsetEnv "HOST_PATH"
 
-    fp <- which "hello"
+  fp <- which "hello"
 
-    shouldEqual fp Nothing
+  shouldEqual fp Nothing
 
-    setEnv "PATH" $ concat $ intersperse ":" [bin, bin2, bin3]
-    setEnv "HOST_PATH" $ concat $ intersperse ":" [bin, bin2]
+  setEnv "PATH" $ concat $ intersperse ":" [bin, bin2, bin3]
+  setEnv "HOST_PATH" $ concat $ intersperse ":" [bin, bin2]
 
-    fp1 <- which "hello"
-    fp2 <- which "hello2"
-    fp3 <- which "hello3"
+  fp1 <- which "hello"
+  fp2 <- which "hello2"
+  fp3 <- which "hello3"
 
-    shouldEqual fp1 (Just $ bin </> "hello")
-    shouldEqual fp2 (Just $ bin2 </> "hello2")
-    shouldEqual fp3 Nothing
+  shouldEqual fp1 (Just $ bin </> "hello")
+  shouldEqual fp2 (Just $ bin2 </> "hello2")
+  shouldEqual fp3 Nothing
 
-    unsetEnv "PATH"
+  unsetEnv "PATH"
 
-    fp4 <- which "hello"
-    fp5 <- which "hello2"
-    fp6 <- which "hello3"
+  fp4 <- which "hello"
+  fp5 <- which "hello2"
+  fp6 <- which "hello3"
 
-    shouldEqual fp4 (Just $ bin </> "hello")
-    shouldEqual fp5 (Just $ bin2 </> "hello2")
-    shouldEqual fp6 Nothing
+  shouldEqual fp4 (Just $ bin </> "hello")
+  shouldEqual fp5 (Just $ bin2 </> "hello2")
+  shouldEqual fp6 Nothing
 
-    unsetEnv "HOST_PATH"
-    setEnv "PATH" $ concat $ intersperse ":" [bin3, bin2, bin]
+  unsetEnv "HOST_PATH"
+  setEnv "PATH" $ concat $ intersperse ":" [bin3, bin2, bin]
 
-    fp7 <- which "hello"
-    fp8 <- which "hello2"
-    fp9 <- which "hello3"
+  fp7 <- which "hello"
+  fp8 <- which "hello2"
+  fp9 <- which "hello3"
 
-    shouldEqual fp7 (Just $ bin3 </> "hello")
-    shouldEqual fp8 (Just $ bin2 </> "hello2")
-    shouldEqual fp9 (Just $ bin3 </> "hello3")
+  shouldEqual fp7 (Just $ bin3 </> "hello")
+  shouldEqual fp8 (Just $ bin2 </> "hello2")
+  shouldEqual fp9 (Just $ bin3 </> "hello3")
 
-    pure ()
+  pure ()

--- a/which.cabal
+++ b/which.cabal
@@ -27,6 +27,17 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs: test
+  build-depends:
+    base,
+    directory,
+    filepath,
+    unix,
+    which
+
 source-repository head
   type: git
   location: https://github.com/obsidiansystems/which

--- a/which.cabal
+++ b/which.cabal
@@ -18,9 +18,11 @@ library
   exposed-modules: System.Which
   build-depends:
     base                >= 4.9.0 && < 4.13,
-    shelly              >= 1.8.0 && < 1.10,
+    directory           >= 1.0 && < 1.4,
+    filepath            >= 1.0 && < 1.5,
     text                >= 1.2.3 && < 1.3,
-    template-haskell    >= 2.11.0 && < 2.15
+    template-haskell    >= 2.11.0 && < 2.15,
+    transformers        >= 0.3.0.0 && < 0.6.0.0
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/which.cabal
+++ b/which.cabal
@@ -1,5 +1,5 @@
 name: which
-version: 0.1.0.0
+version: 0.2.0.0
 license: BSD3
 license-file: LICENSE
 author: Obsidian Systems LLC

--- a/which.cabal
+++ b/which.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules: System.Which
   build-depends:
     base                >= 4.9.0 && < 4.13,
-    directory           >= 1.0 && < 1.4,
+    directory           >= 1.2.4.0 && < 1.4,
     filepath            >= 1.0 && < 1.5,
     text                >= 1.2.3 && < 1.3,
     template-haskell    >= 2.11.0 && < 2.15,

--- a/which.cabal
+++ b/which.cabal
@@ -25,18 +25,21 @@ library
     transformers        >= 0.3.0.0 && < 0.6.0.0
 
   hs-source-dirs:      src
+  ghc-options:         -Wall
   default-language:    Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
-  hs-source-dirs: test
   build-depends:
     base,
     directory,
     filepath,
     unix,
     which
+  hs-source-dirs:      test
+  ghc-options:         -Wall
+  default-language:    Haskell2010
 
 source-repository head
   type: git


### PR DESCRIPTION
We do not always know at build-time where we will get an executable.
For instance, on Nix-less systems, the Nix store will be unavailable
and we need to get it some other way. We could hardcode
/usr/local/bin/ to PATH so that GHC will find it, but this introduces
unnecessary impurities and requires changing hashes between builds. As
a workaround, just use classic “which” functionality.
