### PR TITLE
Bump bounds for GHC 8.8

### DIFF
--- a/which.cabal
+++ b/which.cabal
@@ -17,10 +17,10 @@ tested-with:
 library
   exposed-modules: System.Which
   build-depends:
-    base                >= 4.9.0 && < 4.13,
+    base                >= 4.9.0 && < 4.14,
     shelly              >= 1.8.0 && < 1.10,
     text                >= 1.2.3 && < 1.3,
-    template-haskell    >= 2.11.0 && < 2.15
+    template-haskell    >= 2.11.0 && < 2.16
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
It builds fine with these versions.  I'd recommend using a hackage revision for these changes rather than uploading a new version.