### PR TITLE
Allow GHC 8.10

### DIFF
--- a/which.cabal
+++ b/which.cabal
@@ -17,10 +17,10 @@ tested-with:
 library
   exposed-modules: System.Which
   build-depends:
-    base                >= 4.9.0 && < 4.14,
+    base                >= 4.9.0 && < 4.15,
     shelly              >= 1.8.0 && < 1.10,
     text                >= 1.2.3 && < 1.3,
-    template-haskell    >= 2.11.0 && < 2.16
+    template-haskell    >= 2.11.0 && < 2.17
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Closes #8 

Can the version bounds on Hackage be updated accordingly?